### PR TITLE
 writing LaTeXML's TeX packages should be optional

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -189,16 +189,24 @@ sub install_TeXStyles {
 
 # Install LaTeXML's LaTeX style files into the standard texmf location
 pure_install ::
-	$(NOECHO) $(MKPATH) "$(DESTINSTALLTEXMFDIR)"
-	$(NOECHO) $(MOD_INSTALL) \
-		read "$(INSTALLTEXMFDIR)/.packlist" \
-		write "$(DESTINSTALLTEXMFDIR)/.packlist" \
-		"$(INST_TEXMFDIR)" "$(DESTINSTALLTEXMFDIR)"
-	- $(PERLRUN) -e "exit(1) unless -w shift;" "$(INSTALLTEXMFDIR)" && mktexlsr
+	@if [ -w "$(DESTINSTALLTEXMFDIR)" ]; then \
+		$(NOECHO) $(MKPATH) "$(DESTINSTALLTEXMFDIR)"; \
+		$(NOECHO) $(MOD_INSTALL) \
+			read "$(INSTALLTEXMFDIR)/.packlist" \
+			write "$(DESTINSTALLTEXMFDIR)/.packlist" \
+			"$(INST_TEXMFDIR)" "$(DESTINSTALLTEXMFDIR)"; \
+		- $(PERLRUN) -e "exit(1) unless -w shift;" "$(INSTALLTEXMFDIR)" && mktexlsr; \
+	else \
+		echo "No write permission for TeXMF, skipping installing LaTeXML TeX packages"; \
+	fi
 
 uninstall ::
-	$(NOECHO) $(UNINSTALL) "$(INSTALLTEXMFDIR)/.packlist"
-	- $(PERLRUN) -e "exit(1) unless -w shift;" "$(INSTALLTEXMFDIR)" && mktexlsr
+	@if [ -w "$(DESTINSTALLTEXMFDIR)" ]; then \
+		$(NOECHO) $(UNINSTALL) "$(INSTALLTEXMFDIR)/.packlist"; \
+		- $(PERLRUN) -e "exit(1) unless -w shift;" "$(INSTALLTEXMFDIR)" && mktexlsr; \
+	else
+		echo "No write permission for TeXMF, skipping uninstalling LaTeXML TeX packages"; \
+	fi
 
 InstallTeXStyles
   return; }


### PR DESCRIPTION
For my distributed LaTeXML processing of arXiv, I want to automate the LaTeXML installation on the various machines we are using via a simple cpanminus invocation:

```
cpanm git://github.com/brucemiller/LaTeXML.git@commitSHA
```

When I tried that, it turned out there was a single failure - LaTeXML always attempts to write its TeX package files when a TeX installation is found, assuming it has the required permissions. I have added a check that throws a warning and skips that part of the installation when the texmf directory isn't writable. If I am not mistaken the TeX files are only needed for the manual generation in the first place?
