### PR TITLE
\meaning-parser for \font-defined primitives

### DIFF
--- a/lib/LaTeXML/Common/Font.pm
+++ b/lib/LaTeXML/Common/Font.pm
@@ -167,6 +167,7 @@ sub decodeFontname {
     $props{size} = $size;
     # Experimental Hack !?!?!?
     $props{encoding} = 'OT1' unless defined $props{encoding};
+    $props{at}       = $at . "pt" if defined $at;
     return %props; }
   else {
     return; } }
@@ -199,6 +200,7 @@ sub new {
   my $encoding  = $options{encoding};
   my $language  = $options{language};
   my $mathstyle = $options{mathstyle};
+
   if ($options{forcebold}) {    # for compatibility
     $series = 'bold'; $options{forceseries} = 1; }
   my $flags = 0
@@ -577,6 +579,7 @@ sub merge {
   my $encoding  = $options{encoding};
   my $language  = $options{language};
   my $mathstyle = $options{mathstyle};
+
   if ($options{forcebold}) {    # for compatibility
     $series = 'bold'; $options{forceseries} = 1; }
   my $flags = 0

--- a/lib/LaTeXML/Core/Mouth.pm
+++ b/lib/LaTeXML/Core/Mouth.pm
@@ -285,9 +285,9 @@ sub readToken {
       $line =~ s/((\\ )*)\s*$/$1/s;
       # Then append the appropriaate \endlinechar, or "\r"
       if (my $eol = $STATE->lookupDefinition(T_CS('\endlinechar'))) {
-        # \endlinechar=-1 means what?
+        # \endlinechar<0 or >255 means no character is appended
         $eol = $eol->valueOf()->valueOf;
-        $line .= chr($eol) if $eol > 0; }
+        $line .= chr($eol) if $eol >= 0 and $eol <= 255; }
       else {
         $line .= "\r"; }
       $$self{chars}  = splitChars($line);

--- a/lib/LaTeXML/Package/LaTeX.pool.ltxml
+++ b/lib/LaTeXML/Package/LaTeX.pool.ltxml
@@ -324,6 +324,8 @@ DefConstructorI(T_CS('\begin{document}'), undef, sub {
       push(@boxes, Digest(Tokens(@$ops))); }
     $_[1]->setFont(LookupValue('font'));    # Start w/ whatever font was last selected.
     return @boxes; });
+# \document is used directly in e.g. expl3.sty
+Let(T_CS('\document'), T_CS('\begin{document}'), 'global');
 
 DefConstructorI(T_CS('\end{document}'), undef, sub {
     my ($document) = @_;

--- a/lib/LaTeXML/Package/TeX.pool.ltxml
+++ b/lib/LaTeXML/Package/TeX.pool.ltxml
@@ -840,7 +840,11 @@ DefMacro('\meaning Token', sub {
       if ($type =~ /(primitive|conditional|constructor)$/i) {
         $definition = $definition->getCSorAlias;
         $type       = ref $definition;
-        $type =~ s/^LaTeXML:://; }
+        $type =~ s/^LaTeXML:://;
+        if (my $fontinfo = LookupValue('fontinfo_' . ToString($definition))) {
+          $meaning = 'select font ' . ($$fontinfo{fontname} || 'fontname');
+          $meaning .= ' at ' . $$fontinfo{at} if $$fontinfo{at};
+          $type = 'font'; } }
       # The actual tests start here
       if ($type =~ /token$/i) {
         my $cc         = $definition->getCatcode;
@@ -1282,6 +1286,8 @@ DefPrimitive('\font Token SkipMatch:= SkipSpaces TeXFileName', sub {
     if (!keys %props) {    # Failed?
       Info('unexpected', $name, $stomach, "Unrecognized font name '$name'",
         "Font switch macro " . ToString($cs) . " will have no effect"); }
+    else {
+      $props{fontname} = $name; }
 
     $gullet->skipSpaces;
     AssignValue('fontinfo_' . ToString($cs) => {%props});


### PR DESCRIPTION
Follow-up to (and branched from) #1335 .

After a good debugging session, it turns out that the key missing piece was this little comparison in l3cctab:
```tex
        \exp_args:Nf \str_if_in:nnTF
          { \cs_meaning:N #1 }
          { select~font~cmr10~at~ }
```

In particular, the conditional was failing to evaluate, as my `\meaning` implementation hadn't handled the latexml Primitives created via `\font`. I added some simple extensions to facilitate that (which probably need some discussion), and voila:

:tada: : All tests PASS on texlive 2020, including the latest expl3.sty! :tada:  

With this, we should be able to resolve the most major regression we are facing for the coming 0.8.5 release.