### PR TITLE
More consistent (?) packParameter

### DIFF
--- a/lib/LaTeXML/Core/Definition/Constructor.pm
+++ b/lib/LaTeXML/Core/Definition/Constructor.pm
@@ -53,7 +53,7 @@ sub getReversionSpec {
   my ($self) = @_;
   my $spec = $$self{reversion};
   if ($spec && !ref $spec) {
-    $spec = $$self{reversion} = LaTeXML::Package::TokenizeInternal($spec); }
+    $spec = $$self{reversion} = LaTeXML::Package::TokenizeInternal($spec)->packParameters; }
   return $spec; }
 
 sub getSizer {

--- a/lib/LaTeXML/Core/Parameter.pm
+++ b/lib/LaTeXML/Core/Parameter.pm
@@ -86,7 +86,7 @@ sub read {
   my $value = &{ $$self{reader} }($gullet, @{ $$self{extra} || [] });
   $value = $value->neutralize(@{ $$self{semiverbatim} }) if $$self{semiverbatim} && (ref $value)
     && $value->can('neutralize');
-  $value = $value->packParameters if $value && $$self{macrobody};
+  $value = $value->packParameters if $value && $$self{packParameters};
   $self->revertCatcodes;
   if ((!defined $value) && !$$self{optional}) {
     Error('expected', $self, $gullet,
@@ -103,7 +103,7 @@ sub reparse {
   my ($self, $gullet, $tokens) = @_;
   # Needs neutralization, since the keyvals may have been tokenized already???
   # perhaps a better test would involve whether $tokens is, in fact, Tokens?
-  $tokens = $tokens->packParameters if $tokens && $$self{macrobody};
+  $tokens = $tokens->packParameters if $tokens && $$self{packParameters};
   if (($$self{type} eq 'Plain') || $$self{undigested}) {    # Gack!
     return $tokens; }
   elsif ($$self{semiverbatim}) {                            # Needs neutralization

--- a/lib/LaTeXML/Core/Parameter.pm
+++ b/lib/LaTeXML/Core/Parameter.pm
@@ -86,6 +86,7 @@ sub read {
   my $value = &{ $$self{reader} }($gullet, @{ $$self{extra} || [] });
   $value = $value->neutralize(@{ $$self{semiverbatim} }) if $$self{semiverbatim} && (ref $value)
     && $value->can('neutralize');
+  $value = $value->packParameters if $value && $$self{macrobody};
   $self->revertCatcodes;
   if ((!defined $value) && !$$self{optional}) {
     Error('expected', $self, $gullet,
@@ -102,6 +103,7 @@ sub reparse {
   my ($self, $gullet, $tokens) = @_;
   # Needs neutralization, since the keyvals may have been tokenized already???
   # perhaps a better test would involve whether $tokens is, in fact, Tokens?
+  $tokens = $tokens->packParameters if $tokens && $$self{macrobody};
   if (($$self{type} eq 'Plain') || $$self{undigested}) {    # Gack!
     return $tokens; }
   elsif ($$self{semiverbatim}) {                            # Needs neutralization

--- a/lib/LaTeXML/Core/Token.pm
+++ b/lib/LaTeXML/Core/Token.pm
@@ -84,20 +84,15 @@ sub T_CS { my ($c) = @_; return bless [$c, CC_CS], 'LaTeXML::Core::Token'; }
 # Illegal: don't use unless you know...
 sub T_MARKER { my ($t) = @_; return bless [$t, CC_MARKER], 'LaTeXML::Core::Token'; }
 
-our $STRICT_ARG = 1;
-
 sub T_ARG {
   my ($v) = @_;
   my $int = $v;
   # get the integer value from the token
   if (ref $v eq 'LaTeXML::Core::Token') {
     my $v_str = $$v[0];
-    if (!$STRICT_ARG) {
-      $int = ($v_str =~ /^\d+$/) ? int($v_str) : $v_str; }
-    else {
-      $int = int($$v[0]);
-      if ($int < 1 || $int > 9) {
-        Fatal('malformed', 'T_ARG', 'value should be #1-#9', "Illegal: " . $v->stringify); } } }
+    $int = int($$v[0]);
+    if ($int < 1 || $int > 9) {
+      Fatal('malformed', 'T_ARG', 'value should be #1-#9', "Illegal: " . $v->stringify); } }
   return bless ["$int", CC_ARG], 'LaTeXML::Core::Token'; }
 
 # This hides tokens coming from \the (-like) primitives from expansion; CC_CS,CC_ACTIVE, but also CC_PARAM and CC_ARG

--- a/lib/LaTeXML/Core/Whatsit.pm
+++ b/lib/LaTeXML/Core/Whatsit.pm
@@ -144,7 +144,7 @@ sub substituteParameters {
   my ($self, $spec) = @_;
 # TODO: This is kind of unfortunate -- I am not sure what are the reasonable "entryways" into the Whatsit substituteParameters. For Expandable we now have guarantees that "#,i" has been mapped into a single T_ARG(#i), but not here.
 # so for now run on each call?
-  my @in     = $spec->packParameters->unlist;
+  my @in     = $spec->unlist;
   my @args   = $self->getArgs;
   my $props  = $$self{properties};
   my @result = ();

--- a/lib/LaTeXML/Package.pm
+++ b/lib/LaTeXML/Package.pm
@@ -558,7 +558,7 @@ sub ComposeURL {
 my $parameter_options = {    # [CONSTANT]
   nargs        => 1, reversion   => 1, optional => 1, novalue => 1,
   beforeDigest => 1, afterDigest => 1,
-  semiverbatim => 1, undigested  => 1 };
+  semiverbatim => 1, undigested  => 1, macrobody => 1};
 
 sub DefParameterType {
   my ($type, $reader, %options) = @_;

--- a/lib/LaTeXML/Package.pm
+++ b/lib/LaTeXML/Package.pm
@@ -558,7 +558,7 @@ sub ComposeURL {
 my $parameter_options = {    # [CONSTANT]
   nargs        => 1, reversion   => 1, optional => 1, novalue => 1,
   beforeDigest => 1, afterDigest => 1,
-  semiverbatim => 1, undigested  => 1, macrobody => 1};
+  semiverbatim => 1, undigested  => 1, packParameters => 1};
 
 sub DefParameterType {
   my ($type, $reader, %options) = @_;

--- a/lib/LaTeXML/Package/LaTeX.pool.ltxml
+++ b/lib/LaTeXML/Package/LaTeX.pool.ltxml
@@ -5433,11 +5433,10 @@ DefMacro('\@ifnext@n {} {}{}', sub {
 DefMacro('\@ifstar {}{}', sub {
     my ($gullet, $if, $else) = @_;
     my $next = $gullet->readNonSpace;
-    # NOTE: Not actually substituting, but collapsing ## pairs!!!!
     if (T_OTHER('*')->equals($next)) {
-      $if->substituteParameters()->unlist; }
+      $if; }
     else {
-      ($else->substituteParameters()->unlist, ($next ? $next : ())); } });
+      ($else, ($next ? $next : ())); } });
 
 DefMacro('\@dblarg {}',    '\kernel@ifnextchar[{#1}{\@xdblarg{#1}}');
 DefMacro('\@xdblarg {}{}', '#1[{#2}]{#2}');

--- a/lib/LaTeXML/Package/TeX.pool.ltxml
+++ b/lib/LaTeXML/Package/TeX.pool.ltxml
@@ -115,7 +115,7 @@ DefParameterType('DefPlain', sub {
     if ($inner) {
       ($value) = $inner->reparseArgument($gullet, $value); }
     return $value; },
-  macrobody => 1,
+  packParameters => 1,
   reversion => sub {
     my ($arg, $inner) = @_;
     (T_BEGIN,
@@ -251,7 +251,7 @@ DefParameterType('DefExpanded', sub {
     my $token    = $gullet->readXToken;
     my $expanded = ($token->getCatcode == CC_BEGIN ? $gullet->readBalanced(1) : $token);
     return $expanded; },
-  macrobody => 1,
+  packParameters => 1,
   reversion => sub {
     my ($arg) = @_;
     (T_BEGIN, Revert($arg), T_END); });
@@ -302,7 +302,7 @@ DefParameterType('OptionalUndigested', sub { $_[0]->readOptional; },
 
 # Read a keyword value (KeyVals), that will not be digested.
 DefParameterType('UndigestedKey', sub { $_[0]->readArg; }, undigested => 1);
-DefParameterType('UndigestedDefKey', sub { $_[0]->readArg; }, undigested => 1, macrobody=>1);
+DefParameterType('UndigestedDefKey', sub { $_[0]->readArg; }, undigested => 1, packParameters=>1);
 
 # Read a token as used when defining it, ie. it may be enclosed in braces.
 DefParameterType('DefToken', sub {

--- a/lib/LaTeXML/Package/TeX.pool.ltxml
+++ b/lib/LaTeXML/Package/TeX.pool.ltxml
@@ -114,8 +114,8 @@ DefParameterType('DefPlain', sub {
     my $value = $gullet->readArg;
     if ($inner) {
       ($value) = $inner->reparseArgument($gullet, $value); }
-    $value = $value->packParameters if $value;
     return $value; },
+  macrobody => 1,
   reversion => sub {
     my ($arg, $inner) = @_;
     (T_BEGIN,
@@ -250,9 +250,8 @@ DefParameterType('DefExpanded', sub {
     local $LaTeXML::SMUGGLE_THE = 1;
     my $token    = $gullet->readXToken;
     my $expanded = ($token->getCatcode == CC_BEGIN ? $gullet->readBalanced(1) : $token);
-    $expanded = $expanded->packParameters if $expanded;
-    return $expanded;
-  },
+    return $expanded; },
+  macrobody => 1,
   reversion => sub {
     my ($arg) = @_;
     (T_BEGIN, Revert($arg), T_END); });
@@ -303,6 +302,7 @@ DefParameterType('OptionalUndigested', sub { $_[0]->readOptional; },
 
 # Read a keyword value (KeyVals), that will not be digested.
 DefParameterType('UndigestedKey', sub { $_[0]->readArg; }, undigested => 1);
+DefParameterType('UndigestedDefKey', sub { $_[0]->readArg; }, undigested => 1, macrobody=>1);
 
 # Read a token as used when defining it, ie. it may be enclosed in braces.
 DefParameterType('DefToken', sub {
@@ -6794,9 +6794,9 @@ DefConstructor('\lx@padded[MuDimension]{MuDimension}{}',
 # Building XMDuals for Mathematical Parallel markup
 # Used when the content and presentation forms have different structure.
 
-DefKeyVal('XMath', 'reversion',              'UndigestedKey');
-DefKeyVal('XMath', 'content_reversion',      'UndigestedKey');
-DefKeyVal('XMath', 'presentation_reversion', 'UndigestedKey');
+DefKeyVal('XMath', 'reversion',              'UndigestedDefKey');
+DefKeyVal('XMath', 'content_reversion',      'UndigestedDefKey');
+DefKeyVal('XMath', 'presentation_reversion', 'UndigestedDefKey');
 DefConstructor('\lx@dual OptionalKeyVals:XMath {}{}',
   "<ltx:XMDual $XMath_attributes>#2<ltx:XMWrap>#3</ltx:XMWrap></ltx:XMDual>",
   beforeDigest => sub {
@@ -6907,7 +6907,7 @@ sub I_dual {
   my (@revargs, @pargs, @cargs);
   foreach my $arg (@args) {
     my $id = LaTeXML::Package::getXMArgID();
-    push(@revargs, Tokens(T_PARAM, T_OTHER(ToString($id))));
+    push(@revargs, Tokens(I_arg(ToString($id))));
     push(@pargs,   Invocation(T_CS('\lx@xmarg'), $id, $arg));
     push(@cargs,   Invocation(T_CS('\lx@xmref'), $id)); }
   my $optional = undef;

--- a/lib/LaTeXML/Package/physics.sty.ltxml
+++ b/lib/LaTeXML/Package/physics.sty.ltxml
@@ -16,8 +16,6 @@ use warnings;
 use LaTeXML::Package;
 use LaTeXML::Core::Token;
 
-$LaTeXML::Core::Token::STRICT_ARG = 0;
-
 RequirePackage('amsmath');
 # Currently physics uses xparse, which uses expl3, which is kinda large & rough to process...
 # InputDefinitions('physics', type => 'sty');


### PR DESCRIPTION
Several related bits
* Got rid of `STRICT_ARG`
* tried to be more consistent with where `packParameter` was called
* Added option `macrobody` option for DefParameter, which calls `packParameter` on the arg value.

Not too sure about the name `macrobody`, and maybe this carries "structured" arguments a bit too far?

But it seems to work!