### PR TITLE
[WIP] examples of FinalError for a new kind of softer process termination

### DIFF
--- a/lib/LaTeXML/Common/Error.pm
+++ b/lib/LaTeXML/Common/Error.pm
@@ -25,7 +25,7 @@ our @EXPORT = (
   # Managing STDERR and Logfile messages
   qw(&UseSTDERR &UseLog),
   # Error Reporting
-  qw(&Fatal &Error &Warn &Info),
+  qw(&Fatal &FinalError &Error &Warn &Info),
   # General messages
   qw(&Note &NoteSTDERR &NoteLog),
   # Progress Spinner
@@ -337,7 +337,22 @@ sub Error {
   # Note that "100" is hardwired into TeX, The Program!!!
   my $maxerrors = ($state ? $state->lookupValue('MAX_ERRORS') : 100);
   if ($state && (defined $maxerrors) && (($state->getStatus('error') || 0) > $maxerrors)) {
-    Fatal('too_many_errors', $maxerrors, $where, "Too many errors (> $maxerrors)!"); }
+    FinalError('too_many_errors', $maxerrors, $where, "Too many errors (> $maxerrors)!"); }
+  return; }
+
+# An Error which also yanks the remainder of any yet-to-be-processed data.
+#
+# Hopes to achieve better recovery than a hard Fatal().
+#   Can be used for cases where processing can realistically
+#   be expected to continue in its *NEXT PHASES*
+#
+# but *NOT* trusted with the rest of the content -
+#   if we thought more content can be processed,
+#   the softer Error() is appropriate.
+sub FinalError {
+  my ($category, $object, $where, $message, @details) = @_;
+  Error($category, $object, $where, $message, @details);
+  hardYankProcessing();
   return; }
 
 # Warning message; results may be OK, but somewhat unlikely

--- a/lib/LaTeXML/Core/Gullet.pm
+++ b/lib/LaTeXML/Core/Gullet.pm
@@ -249,7 +249,7 @@ sub handleTemplate {
 
 # If it is a column ending token, Returns the token, a keyword and whether it is "hidden"
 our @column_ends = (
-  [T_ALIGN, 'align', 0],
+  [T_ALIGN,               'align',  0],
   [T_CS('\cr'),           'cr',     0],
   [T_CS('\crcr'),         'crcr',   0],
   [T_CS('\hidden@cr'),    'cr',     1],
@@ -307,7 +307,7 @@ sub unread {
     map { (!defined $_ ? ()
         : (($r = ref $_) eq 'LaTeXML::Core::Token' ? $_
           : ($r eq 'LaTeXML::Core::Tokens' ? @$_
-            : Fatal('misdefined', $r, undef, "Expected a Token, got " . Stringify($_))))) }
+            : FinalError('misdefined', $r, undef, "Expected a Token, got " . Stringify($_))))) }
       @tokens);
   return; }
 
@@ -655,7 +655,7 @@ sub readTokensValue {
   my $token = $self->readNonSpace;
   if (!defined $token) {
     return; }
-  elsif ($$token[1] == CC_BEGIN) {             # Inline ->getCatcode!
+  elsif ($$token[1] == CC_BEGIN) {    # Inline ->getCatcode!
     return $self->readBalanced; }
   elsif (my $defn = $STATE->lookupDefinition($token)) {
     if ($defn->isRegister eq 'Tokens') {
@@ -666,7 +666,7 @@ sub readTokensValue {
         $self->unread(@{$x}); }
       return $self->readTokensValue; }
     else {
-      return $token; } }                       # ?
+      return $token; } }    # ?
   else {
     return $token; } }
 

--- a/lib/LaTeXML/Core/Token.pm
+++ b/lib/LaTeXML/Core/Token.pm
@@ -59,9 +59,9 @@ use constant CC_ACTIVE  => 13;
 use constant CC_COMMENT => 14;
 use constant CC_INVALID => 15;
 # Extended Catcodes for expanded output.
-use constant CC_CS        => 16;
-use constant CC_MARKER    => 17;    # non TeX extension!
-use constant CC_ARG       => 18;    # "out_param" in B Book
+use constant CC_CS          => 16;
+use constant CC_MARKER      => 17;    # non TeX extension!
+use constant CC_ARG         => 18;    # "out_param" in B Book
 use constant CC_SMUGGLE_THE => 19;    # defered expansion once
 
 # [The documentation for constant is a bit confusing about subs,
@@ -76,11 +76,11 @@ use constant T_SUPER => bless ['^',  CC_SUPER], 'LaTeXML::Core::Token';
 use constant T_SUB   => bless ['_',  CC_SUB],   'LaTeXML::Core::Token';
 use constant T_SPACE => bless [' ',  CC_SPACE], 'LaTeXML::Core::Token';
 use constant T_CR    => bless ["\n", CC_SPACE], 'LaTeXML::Core::Token';
-sub T_LETTER { my ($c) = @_; return bless [$c, CC_LETTER], 'LaTeXML::Core::Token'; }
-sub T_OTHER  { my ($c) = @_; return bless [$c, CC_OTHER],  'LaTeXML::Core::Token'; }
-sub T_ACTIVE { my ($c) = @_; return bless [$c, CC_ACTIVE], 'LaTeXML::Core::Token'; }
+sub T_LETTER  { my ($c) = @_; return bless [$c, CC_LETTER], 'LaTeXML::Core::Token'; }
+sub T_OTHER   { my ($c) = @_; return bless [$c, CC_OTHER],  'LaTeXML::Core::Token'; }
+sub T_ACTIVE  { my ($c) = @_; return bless [$c, CC_ACTIVE], 'LaTeXML::Core::Token'; }
 sub T_COMMENT { my ($c) = @_; return bless ['%' . ($c || ''), CC_COMMENT], 'LaTeXML::Core::Token'; }
-sub T_CS { my ($c) = @_; return bless [$c, CC_CS], 'LaTeXML::Core::Token'; }
+sub T_CS      { my ($c) = @_; return bless [$c, CC_CS], 'LaTeXML::Core::Token'; }
 # Illegal: don't use unless you know...
 sub T_MARKER { my ($t) = @_; return bless [$t, CC_MARKER], 'LaTeXML::Core::Token'; }
 
@@ -92,7 +92,7 @@ sub T_ARG {
     my $v_str = $$v[0];
     $int = int($$v[0]);
     if ($int < 1 || $int > 9) {
-      Fatal('malformed', 'T_ARG', 'value should be #1-#9', "Illegal: " . $v->stringify); } }
+      FinalError('malformed', 'T_ARG', 'value should be #1-#9', "Illegal: " . $v->stringify); } }
   return bless ["$int", CC_ARG], 'LaTeXML::Core::Token'; }
 
 # This hides tokens coming from \the (-like) primitives from expansion; CC_CS,CC_ACTIVE, but also CC_PARAM and CC_ARG
@@ -219,7 +219,7 @@ our @CATCODE_SHORT_NAME =          #[CONSTANT]
   T_SUB T_IGNORE T_SPACE T_LETTER
   T_OTHER T_ACTIVE T_COMMENT T_INVALID
   T_CS T_MARKER T_ARG T_SMUGGLE_THE
-);
+  );
 
 our $SMUGGLE_THE_COMMANDS = {
   '\the'        => 1,
@@ -309,7 +309,7 @@ sub with_dont_expand {
   my $cc = $$self[1];
   if ($cc == CC_SMUGGLE_THE) {
     # LaTeXML Bug, we haven't correctly emulated scan_toks! Offending token was:
-    Fatal('unexpected', 'CC_SMUGGLE_THE', 'We are marking as \noexpand a masked \the-produced token, this must Never happen.', "Illegal: " . $self->stringify); }
+    FinalError('unexpected', 'CC_SMUGGLE_THE', 'We are marking as \noexpand a masked \the-produced token, this must Never happen.', "Illegal: " . $self->stringify); }
   return ((($cc == CC_CS) || ($cc == CC_ACTIVE))
     # AND it is either undefined, or is expandable!
       && (!defined($STATE->lookupDefinition($self))


### PR DESCRIPTION
For the purposes of brainstorming. 

Some Errors could be considered "Final" without triggering a perl "die", but rather a soft "yank" of the remaining processing data stream.

Ideally this allows for still obtaining a workable demonstration with all follow-up phases executed faithfully. E.g. a "FinalError" in section 5, should still get the first 4 sections continue to get rewrites, properly parse math, and execute post-processing.

Some errors I thought may be good examples for this:
 * `too_many_errors` can just be a final error in core processing, but still continue normally to the next phase
 * a `misdefined` token in `Gullet::unread` could just finalize core processing, but still continue normally to the next phase
 * a wrongly used `T_ARG` or `CC_SMUGGLED_THE` should certainly stop processing any further content (as they are too scarily wrong), but a perl `die` is likely a bit too severe.

And I'm sure more can be fished out... The tricky bit is testing this, since I don't have examples for now, only suggestions.